### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A service to sync **ScoutCH hitobito_pbs** members as contacts to Microsoft 365 (M365) and automate camp-based distribution groups. Uses Microsoft Graph API with security-first design.
 
 > **ℹ️ Info:**
-> Active Development happens in Alpha-1 Branche, if you want to see current development State!
+> Active Development happens in Alpha-1 branch, if you want to see current development State!
 
 ---
 


### PR DESCRIPTION
## Summary
- fix a typo in README referencing the development branch
