### PR TITLE
Fix MiData-API doc trailing line

### DIFF
--- a/Architecture/MiData-API.md
+++ b/Architecture/MiData-API.md
@@ -20,4 +20,3 @@
 | GET    | /api/event_kind_categories/:id | Fetch a single event kind category, replace :id with the event's primary key |
 
 # Hitobito Get Idea
-layer_group_id


### PR DESCRIPTION
## Summary
- clean up stray `layer_group_id` leftover in Architecture/MiData-API.md
